### PR TITLE
feat: add OpenAI API key to docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,9 @@ services:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - REDIS_DB=${REDIS_DB:-0}
 
+      # OpenAI
+      - OPENAI_API_KEY_1=${OPENAI_API_KEY_1}
+
     volumes:
       - uploads_data:/app/uploads
     networks:


### PR DESCRIPTION
- Included OPENAI_API_KEY_1 as an environment variable in the docker-compose.yml file to support OpenAI integration.